### PR TITLE
Move keyring pkg to Suggests list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: R
-sudo: false
 cache: packages
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:chris-lea/libsodium'
+    packages:
+      - libsecret-1-dev
+      - libsodium-dev

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Imports:
     magrittr,
     dplyr,
     httr,
-    keyring, 
     leaflet, 
     tibble
+Suggests:
+    keyring


### PR DESCRIPTION
With this change, we are making **keyring** a suggested package. We can add in some code that warns about not having the package installed if there is ever a **keyring** function call inside **yelpr**.